### PR TITLE
PyPi Automatic Publish on New Release

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,37 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  publish-pypi:
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/natural-language-geocoding/
+    permissions:
+      id-token: write
+    if: ${{ github.repository }} == 'Element84/natural-language-geocoding'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+
+      - name: Build package
+        run: python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          verbose: true

--- a/.github/workflows/testpypi-publish.yml
+++ b/.github/workflows/testpypi-publish.yml
@@ -1,9 +1,10 @@
 name: Publish to Test PyPI
 
 on:
-  push:
-    branches:
-      - 'brian/auto-pypi-publish'
+  release:
+    types:
+      - published
+
 jobs:
   publish-testpypi:
     runs-on: ubuntu-latest

--- a/.github/workflows/testpypi-publish.yml
+++ b/.github/workflows/testpypi-publish.yml
@@ -1,0 +1,36 @@
+name: Publish to Test PyPI
+
+on:
+  push:
+    branches:
+      - 'brian/auto-pypi-publish'
+jobs:
+  publish-testpypi:
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://pypi.org/p/natural-language-geocoding/
+    permissions:
+      id-token: write
+    if: ${{ github.repository }} == 'Element84/natural-language-geocoding'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+      - name: Build package
+        run: python -m build
+
+      - name: Publish to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          verbose: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools_scm"]
+requires = ["setuptools", "setuptools-git-versioning"]
 build-backend = "setuptools.build_meta"
 
 
@@ -17,7 +17,10 @@ dependencies = [
 ]
 dynamic = ["version"]
 
-[tool.setuptools_scm]
+[tool.setuptools-git-versioning]
+enabled = true
+dev_template = "{tag}"
+dirty_template = "{tag}"
 
 [project.urls]
 Github = "https://github.com/Element84/natural-language-geocoding"


### PR DESCRIPTION
To publish to pypi:
1. Create new tag with version. Has to be only numbers (i.e. '0.0.2' is valid, '0.0.1-test' is not)
2. Create new release with that tag. 
3. Approve the job to run in Actions tab. There is both testpypi and pypi - pypi is the one that publishes the package to production. We could always remove the approval step by going to environment and unchecking 'required reviewers'. 

Development:
1. Created the 2 pypi-publish yml files
2. Created 2 new environments (Both have protection rules that make an admin authorize the job before it runs):
   a. testpypi
   b. pypi
3. on https://test.pypi.org/ and https://pypi.org/ I added the repo and environments in 'publishing'

