### PR TITLE
Updating dependencies for critical vulnerability

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ demo = [
   "streamlit-folium>=0.22.1",
   "watchdog>=6.0.0"]
 eval = [
-  "deepdiff",
+  "deepdiff>=8.6.1",
   "zss"]
 dev = [
   "pytest>=8.3.3",

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,45 +14,45 @@ attrs==25.3.0
     #   referencing
 blinker==1.9.0
     # via streamlit
-boto3==1.39.1
+boto3==1.40.26
     # via e84-geoai-common
-boto3-stubs==1.39.1
+boto3-stubs==1.40.26
     # via e84-geoai-common
-botocore==1.39.1
+botocore==1.40.26
     # via
     #   boto3
     #   s3transfer
-botocore-stubs==1.38.46
+botocore-stubs==1.40.26
     # via boto3-stubs
 branca==0.8.1
     # via
     #   folium
     #   streamlit-folium
-build==1.2.2.post1
+build==1.3.0
     # via natural-language-geocoding (pyproject.toml)
-cachetools==6.1.0
+cachetools==6.2.0
     # via streamlit
-certifi==2025.6.15
+certifi==2025.8.3
     # via
     #   opensearch-py
     #   requests
 cfgv==3.4.0
     # via pre-commit
-charset-normalizer==3.4.2
+charset-normalizer==3.4.3
     # via requests
 click==8.2.1
     # via streamlit
 colorama==0.4.6
     # via pytest-watch
-comm==0.2.2
+comm==0.2.3
     # via ipykernel
-debugpy==1.8.14
+debugpy==1.8.16
     # via ipykernel
 decorator==5.2.1
     # via ipython
-deepdiff==8.5.0
+deepdiff==8.6.1
     # via natural-language-geocoding (pyproject.toml)
-distlib==0.3.9
+distlib==0.4.0
     # via virtualenv
 docopt==0.6.2
     # via pytest-watch
@@ -60,9 +60,9 @@ e84-geoai-common==0.0.6
     # via natural-language-geocoding (pyproject.toml)
 events==0.5
     # via opensearch-py
-executing==2.2.0
+executing==2.2.1
     # via stack-data
-filelock==3.18.0
+filelock==3.19.1
     # via virtualenv
 folium==0.20.0
     # via streamlit-folium
@@ -70,17 +70,17 @@ function-schema==0.4.5
     # via e84-geoai-common
 gitdb==4.0.12
     # via gitpython
-gitpython==3.1.44
+gitpython==3.1.45
     # via streamlit
-identify==2.6.12
+identify==2.6.14
     # via pre-commit
 idna==3.10
     # via requests
 iniconfig==2.1.0
     # via pytest
-ipykernel==6.29.5
+ipykernel==6.30.1
     # via natural-language-geocoding (pyproject.toml)
-ipython==9.4.0
+ipython==9.5.0
     # via ipykernel
 ipython-pygments-lexers==1.1.1
     # via ipython
@@ -97,9 +97,9 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-jsonschema==4.24.0
+jsonschema==4.25.1
     # via altair
-jsonschema-specifications==2025.4.1
+jsonschema-specifications==2025.9.1
     # via jsonschema
 jupyter-client==8.6.3
     # via ipykernel
@@ -107,7 +107,7 @@ jupyter-core==5.8.1
     # via
     #   ipykernel
     #   jupyter-client
-markdown-it-py==3.0.0
+markdown-it-py==4.0.0
     # via rich
 markupsafe==3.0.2
     # via jinja2
@@ -117,15 +117,15 @@ matplotlib-inline==0.1.7
     #   ipython
 mdurl==0.1.2
     # via markdown-it-py
-mypy-boto3-bedrock==1.39.0
+mypy-boto3-bedrock==1.40.7
     # via boto3-stubs
-mypy-boto3-bedrock-runtime==1.39.0
+mypy-boto3-bedrock-runtime==1.40.21
     # via
     #   boto3-stubs
     #   e84-geoai-common
-mypy-boto3-s3==1.39.0
+mypy-boto3-s3==1.40.26
     # via boto3-stubs
-narwhals==1.45.0
+narwhals==2.4.0
     # via altair
 nest-asyncio==1.6.0
     # via ipykernel
@@ -133,7 +133,7 @@ nodeenv==1.9.1
     # via
     #   pre-commit
     #   pyright
-numpy==2.3.1
+numpy==2.3.2
     # via
     #   folium
     #   pandas
@@ -143,7 +143,7 @@ numpy==2.3.1
     #   types-shapely
 opensearch-py==3.0.0
     # via natural-language-geocoding (pyproject.toml)
-orderly-set==5.4.1
+orderly-set==5.5.0
     # via deepdiff
 packaging==25.0
     # via
@@ -152,27 +152,27 @@ packaging==25.0
     #   ipykernel
     #   pytest
     #   streamlit
-pandas==2.3.0
+pandas==2.3.2
     # via streamlit
-parso==0.8.4
+parso==0.8.5
     # via jedi
 pexpect==4.9.0
     # via ipython
 pillow==11.3.0
     # via streamlit
-platformdirs==4.3.8
+platformdirs==4.4.0
     # via
     #   jupyter-core
     #   virtualenv
 pluggy==1.6.0
     # via pytest
-pre-commit==4.2.0
+pre-commit==4.3.0
     # via natural-language-geocoding (pyproject.toml)
-pre-commit-hooks==5.0.0
+pre-commit-hooks==6.0.0
     # via natural-language-geocoding (pyproject.toml)
-prompt-toolkit==3.0.51
+prompt-toolkit==3.0.52
     # via ipython
-protobuf==6.31.1
+protobuf==6.32.0
     # via streamlit
 psutil==7.0.0
     # via ipykernel
@@ -180,7 +180,7 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
     # via stack-data
-pyarrow==20.0.0
+pyarrow==21.0.0
     # via streamlit
 pydantic==2.11.7
     # via e84-geoai-common
@@ -196,9 +196,9 @@ pygments==2.19.2
     #   rich
 pyproject-hooks==1.2.0
     # via build
-pyright==1.1.402
+pyright==1.1.405
     # via natural-language-geocoding (pyproject.toml)
-pytest==8.4.1
+pytest==8.4.2
     # via
     #   natural-language-geocoding (pyproject.toml)
     #   pytest-watch
@@ -214,7 +214,7 @@ pytz==2025.2
     # via pandas
 pyyaml==6.0.2
     # via pre-commit
-pyzmq==27.0.0
+pyzmq==27.1.0
     # via
     #   ipykernel
     #   jupyter-client
@@ -222,27 +222,27 @@ referencing==0.36.2
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.32.4
+requests==2.32.5
     # via
     #   natural-language-geocoding (pyproject.toml)
     #   folium
     #   opensearch-py
     #   streamlit
-rich==14.0.0
+rich==14.1.0
     # via
     #   natural-language-geocoding (pyproject.toml)
     #   e84-geoai-common
-rpds-py==0.26.0
+rpds-py==0.27.1
     # via
     #   jsonschema
     #   referencing
-ruamel-yaml==0.18.14
+ruamel-yaml==0.18.15
     # via pre-commit-hooks
 ruamel-yaml-clib==0.2.12
     # via ruamel-yaml
-ruff==0.12.1
+ruff==0.12.12
     # via natural-language-geocoding (pyproject.toml)
-s3transfer==0.13.0
+s3transfer==0.13.1
     # via boto3
 shapely==2.1.1
     # via e84-geoai-common
@@ -254,11 +254,11 @@ smmap==5.0.2
     # via gitdb
 stack-data==0.6.3
     # via ipython
-streamlit==1.46.1
+streamlit==1.49.1
     # via
     #   natural-language-geocoding (pyproject.toml)
     #   streamlit-folium
-streamlit-folium==0.25.0
+streamlit-folium==0.25.1
     # via natural-language-geocoding (pyproject.toml)
 tabulate==0.9.0
     # via natural-language-geocoding (pyproject.toml)
@@ -266,26 +266,25 @@ tenacity==9.1.2
     # via streamlit
 toml==0.10.2
     # via streamlit
-tornado==6.5.1
+tornado==6.5.2
     # via
     #   ipykernel
     #   jupyter-client
     #   streamlit
 traitlets==5.14.3
     # via
-    #   comm
     #   ipykernel
     #   ipython
     #   jupyter-client
     #   jupyter-core
     #   matplotlib-inline
-types-awscrt==0.27.4
+types-awscrt==0.27.6
     # via botocore-stubs
-types-s3transfer==0.13.0
+types-s3transfer==0.13.1
     # via boto3-stubs
-types-shapely==2.1.0.20250512
+types-shapely==2.1.0.20250822
     # via e84-geoai-common
-typing-extensions==4.14.0
+typing-extensions==4.15.0
     # via
     #   altair
     #   pydantic
@@ -303,7 +302,7 @@ urllib3==2.5.0
     #   botocore
     #   opensearch-py
     #   requests
-virtualenv==20.31.2
+virtualenv==20.34.0
     # via pre-commit
 watchdog==6.0.0
     # via


### PR DESCRIPTION
Updates for following issue:


>  Upgrade deepdiff@8.5.0 to deepdiff@8.6.1 to fix
>  ✗ Class Pollution (new) [Critical Severity][https://security.snyk.io/vuln/SNYK-PYTHON-DEEPDIFF-12485343] in >deepdiff@8.5.0
>    introduced by deepdiff@8.5.0